### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,15 +53,29 @@ Calculated semantic version string
 Simples example of using the action:
 
 ```yaml
+---
 on:
   push:
     branches: [main]
+
+name: Generate SemVer Version
+
+permissions:
+  contents: read
+
+concurrency:
+  group: "${{ github.ref }}-${{ github.workflow }}"
+  cancel-in-progress: true
+
 jobs:
   versioning:
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
+
     steps:
       - name: Checkout code
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           fetch-depth: 0
           fetch-tags: true
@@ -69,22 +83,35 @@ jobs:
         id: calculate-version
         uses: bitshifted/git-auto-semver@v1
       - name: Use version
-        run: echo "Calculated version: ${{ steps.calculate-version.outputs.version-string }}"
+        run: 'echo "Calculated version: ${{ steps.calculate-version.outputs.version-string }}"'
 
 ```
 
 With customized parameters:
 
 ```yaml
+---
 on:
   push:
     branches: [main]
+
+name: Generate SemVer Version
+
+permissions:
+  contents: read
+
+concurrency:
+  group: "${{ github.ref }}-${{ github.workflow }}"
+  cancel-in-progress: true
+
 jobs:
   versioning:
+    permissions:
+      contents: write
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           fetch-depth: 0
           fetch-tags: true
@@ -96,8 +123,17 @@ jobs:
           create_tag: true
           tag_prefix: 'tags'
       - name: Use version
-        run: echo "Calculated version: ${{ steps.calculate-version.outputs.version-string }}"
+        run: 'echo "Calculated version: ${{ steps.calculate-version.outputs.version-string }}"'
 ```
 ## Troubleshooting
 
 Make sure to set `fetch-depth: 0` and `fetch-tags: true` in the checkout action. This will pull all data needed for semver to work correctly.
+
+If you receive a `Resource not accessible by integration` error, be sure that either the `GITHUB_TOKEN` has permission to write content (to create a tag) or the permissions for the job:
+
+```yaml
+jobs:
+  versioning:
+    permissions:
+      contents: write
+```


### PR DESCRIPTION
This extends the documentation to include setting the jobs' permissions levels so that tags may be created.  The Troubleshooting section describes the error some may see if the permissions are not set properly (especially when tags are being created).  Also the checkout action was bumped from v3 to v4.