### PR TITLE
fix: get latest tag

### DIFF
--- a/scripts/version.sh
+++ b/scripts/version.sh
@@ -13,13 +13,13 @@ PATCH_REGEX='^(build|chore|ci|docs|fix|perf|refactor|revert|style|test)\s?(\(.+\
 MINOR_REGEX='^(feat)\s*(\(.+\))?\s?:\s*(.+)'
 MAJOR_REGEX='^(BREAKING CHANGE)\s*(\(.+\))?\s?:\s*(.+)'
 
-if [ "$1" = "--pull-request" ];then 
+if [ "$1" = "--pull-request" ];then
   git rev-parse --short HEAD
   exit 0
 fi
 
 # get the latest tag
-LATEST_TAG=$(git describe --tags `git rev-list --tags --max-count=1`  2> /dev/null)
+LATEST_TAG=$(git tag -l | sort -V | tail -n 1 2> /dev/null)
 if [ -z $LATEST_TAG ]; then
   LATEST_TAG="$INPUT_INITIAL_VERSION"
   echo "$LATEST_TAG"


### PR DESCRIPTION
I had a bunch of tags already available in my git repo:

```
$ git tag -l | sort -V
v1.0.0
v1.1.0
v1.2.0
v1.3.0
v1.4.0
v1.5.0
v1.6.0
v1.7.0
v1.8.0
v1.9.0
v1.10.0
v1.11.0
v1.12.0
v1.13.0
v1.13.1
v1.14.0
v1.14.1
v1.14.2
v2.0.0
v2.1.0
```

but my use of this GHA always resulted in creating a new v1.0.1 tag.  I attempted removing all tags and recreating them, but nothing seemed to help.

I ended up deciding to patch the logic to retrieve the latest tag in this PR.