### PR TITLE
fix: Fix tagging problem

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -25,5 +25,5 @@ jobs:
           echo "Tagging version: ${{ steps.generate-version.outputs.version-string }}"
           git tag  v${{ steps.generate-version.outputs.version-string }}
           git tag --force v1 v${{ steps.generate-version.outputs.version-string }}
-          git push origin --tags
+          git push origin --force v1
             

--- a/README.md
+++ b/README.md
@@ -60,6 +60,11 @@ jobs:
   versioning:
     runs-on: ubuntu-latest
     steps:
+      - name: Checkout code
+        uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
+          fetch-tags: true
       - name: calculate version
         id: calculate-version
         uses: bitshifted/git-auto-semver@v1
@@ -78,6 +83,11 @@ jobs:
   versioning:
     runs-on: ubuntu-latest
     steps:
+      - name: Checkout code
+        uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
+          fetch-tags: true
       - name: calculate version
         id: calculate-version
         uses: bitshifted/git-auto-semver@v1
@@ -88,3 +98,6 @@ jobs:
       - name: Use version
         run: echo "Calculated version: ${{ steps.calculate-version.outputs.version-string }}"
 ```
+## Troubleshooting
+
+Make sure to set `fetch-depth: 0` and `fetch-tags: true` in the checkout action. This will pull all data needed for semver to work correctly.


### PR DESCRIPTION
Pushing new tags to remote fails with `tag already exists` message.