### PR TITLE
BREAKING CHANGE: change tag version handling

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -13,6 +13,8 @@ jobs:
         with:
           fetch-depth: 0
           fetch-tags: true
+      - name: test regex
+        run: git tag -l --sort=v:refname | grep -E  "[0-9]\.[0-9]\.[0-9]$" | tail -n 1
       - name: Generate version
         id: generate-version
         uses: ./

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -13,8 +13,6 @@ jobs:
         with:
           fetch-depth: 0
           fetch-tags: true
-      - name: test regex
-        run: git tag -l --sort=v:refname | grep -E  "[0-9]\.[0-9]\.[0-9]$" | tail -n 1
       - name: Generate version
         id: generate-version
         uses: ./

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -26,7 +26,7 @@ jobs:
         run: |
           echo "Tagging version: ${{ steps.generate-version.outputs.version-string }}"
           git tag  v${{ steps.generate-version.outputs.version-string }}
-          git tag --force v1 v${{ steps.generate-version.outputs.version-string }}
+          git tag --force v2 v${{ steps.generate-version.outputs.version-string }}
           git push origin v${{ steps.generate-version.outputs.version-string }}
-          git push origin --force v1
+          git push origin --force v2
             

--- a/README.md
+++ b/README.md
@@ -18,6 +18,13 @@ feat: add new awesome feature
 
 This will bump version number to `1.2.0`, since `feat` marks a change in minor version.
 
+## Upgrading from version v1 to v2
+
+In version `v2`, some changes are made in the way semver tags are processed. Specifically, action checks tags Semantic Versioning format, and takes the latest tag
+conforming to Semantic versioning as current version.
+
+In most of the cases, upgrade should be seamless, but if you have some tags that so not conform to semver format, you might get unexpected results.
+
 ## Main branch and pull request
 
 This action assumes that each push (merge) to the main branch will create new version of software, with corresponding semantic version. By default, main branch is assumed to be `main`, but this can be overriden in configuration. Each push to this branch will create new version.
@@ -86,7 +93,7 @@ jobs:
           fetch-tags: true
       - name: calculate version
         id: calculate-version
-        uses: bitshifted/git-auto-semver@v1
+        uses: bitshifted/git-auto-semver@v2
       - name: Use version
         run: 'echo "Calculated version: ${{ steps.calculate-version.outputs.version-string }}"'
 
@@ -127,7 +134,7 @@ jobs:
           fetch-tags: true
       - name: calculate version
         id: calculate-version
-        uses: bitshifted/git-auto-semver@v1
+        uses: bitshifted/git-auto-semver@v2
         with:
           main_branch: master
           create_tag: true

--- a/scripts/entrypoint.sh
+++ b/scripts/entrypoint.sh
@@ -11,6 +11,7 @@ VERSION_STRING="$INPUT_INITIAL_VERSION"
 
 if [ "$GITHUB_EVENT_NAME" = "pull_request" ]; then
     VERSION_STRING=$(version.sh --pull-request)
+    echo "Pull request version string: $VERSION_STRING"
 else
     if [ "$GITHUB_REF" = "refs/heads/$INPUT_MAIN_BRANCH" ]; then
         VERSION_STRING=$(version.sh) || exit 1

--- a/scripts/version.sh
+++ b/scripts/version.sh
@@ -14,12 +14,13 @@ MINOR_REGEX='^(feat)\s*(\(.+\))?\s?:\s*(.+)'
 MAJOR_REGEX='^(BREAKING CHANGE)\s*(\(.+\))?\s?:\s*(.+)'
 
 if [ "$1" = "--pull-request" ];then 
-  git rev-parse --short HEAD
+  # git rev-parse --short HEAD
+  git tag -l --sort=v:refname | grep -E  "[0-9]\.[0-9]\.[0-9]$" | tail -n 1
   exit 0
 fi
 
 # get the latest tag
-LATEST_TAG=$(git describe --tags `git rev-list --tags --max-count=1`  2> /dev/null)
+LATEST_TAG=$(git tag -l --sort=v:refname | grep -E  "[0-9]\.[0-9]\.[0-9]$" | tail -n 1)
 if [ -z $LATEST_TAG ]; then
   LATEST_TAG="$INPUT_INITIAL_VERSION"
   echo $LATEST_TAG

--- a/scripts/version.sh
+++ b/scripts/version.sh
@@ -14,8 +14,7 @@ MINOR_REGEX='^(feat)\s*(\(.+\))?\s?:\s*(.+)'
 MAJOR_REGEX='^(BREAKING CHANGE)\s*(\(.+\))?\s?:\s*(.+)'
 
 if [ "$1" = "--pull-request" ];then 
-  # git rev-parse --short HEAD
-  git tag -l --sort=v:refname | grep -E  "[0-9]\.[0-9]\.[0-9]$" | tail -n 1
+  git rev-parse --short HEAD
   exit 0
 fi
 


### PR DESCRIPTION
Change the way version tags are processed to be more inline with Semantic Versioning approach.
**Warning:** This change might cause problems with existing tagging scheme, so it is marked as breaking change.
Close #18 