### PR TITLE
fix(tag prefix): removes check to make tag prefix mandatory

### DIFF
--- a/scripts/version.sh
+++ b/scripts/version.sh
@@ -37,11 +37,6 @@ for ((i=1; i<=$#; i++)); do
   fi
 done
 
-if [ -z "$TAG_PREFIX" ]; then
-  echo "Error: --tag-prefix is a mandatory parameter" >&2
-  exit 1
-fi
-
 # get the latest tag
 LATEST_TAG=$(git tag -l --sort=v:refname | grep -E  "${TAG_PREFIX}[0-9]+\.[0-9]+\.[0-9]+$" | tail -n 1)
 if [ -z $LATEST_TAG ]; then


### PR DESCRIPTION
Possible fix for #39. This was tested and worked on a test repo of mine where I set `tag_prefix: ""`. It found my existing tag and incremented it.

I read through the code. This seems to be all that is needed. Although, this code is new to me. I may have missed something. If I am completely oblivious, I won't be offended if you decline this pull request :-)